### PR TITLE
Change workaround for fatal error on acquire fail

### DIFF
--- a/eqw_takp/dinput_manager.h
+++ b/eqw_takp/dinput_manager.h
@@ -19,7 +19,7 @@
 namespace DInputManager {
 
 void Initialize(HMODULE handle);
-void SetBackgroundMode(bool background_mode);  // Set during eqmain.
+void SetIgnorePrioInAcquire(bool ignore_prio_result);  // Set during eqmain.
 void Acquire(bool keyboard_only = false);
 void Unacquire();
 void FlushMouse();

--- a/eqw_takp/eq_main.cpp
+++ b/eqw_takp/eq_main.cpp
@@ -440,7 +440,7 @@ HWND WINAPI User32CreateWindowExAHook(DWORD dwExStyle, LPCSTR lpClassName, LPCST
   SetWindowPos(hwnd_, 0, X, Y, win_width_, win_height_, 0);
   UpdateClientRegion(hwnd_);
 
-  DInputManager::SetBackgroundMode(true);  // eqmain.dll will crash if keyboard acquire fails.
+  DInputManager::SetIgnorePrioInAcquire(true);  // eqmain.dll throws a fatal error if keyboard acquire fails.
 
   return hwnd_;
 }
@@ -470,7 +470,7 @@ BOOL WINAPI User32DestroyWindowHook(HWND hwnd) {
   eqmain_wndproc_ = nullptr;
   ::SetWindowLongA(hwnd_, GWL_WNDPROC, (LONG)original_wndproc_);
 
-  DInputManager::SetBackgroundMode(false);  // Let eqgame.exe run in foreground only mode.
+  DInputManager::SetIgnorePrioInAcquire(false);  // eqgame.exe can handle sharing keyboard dinput access.
 
   return true;
 }


### PR DESCRIPTION
- The eqmain.dll throws a fatal error if the keyboard dinput acquire fails (doesn't have focus)
  - The previous workaround was to run in background mode to always make acquire succeed, but a bug was reported where a minimized eqmain would trigger on activity in another app with focus
  - Changed the workaround so that the acquire returns success even if other app has prio during eqmain and now running in foreground mode to avoid misdirected inputs